### PR TITLE
thor is required

### DIFF
--- a/lib/private_gem/cli.rb
+++ b/lib/private_gem/cli.rb
@@ -1,4 +1,5 @@
 require 'bundler/cli'
+require 'thor'
 
 module PrivateGem
   class CLI < Thor


### PR DESCRIPTION
Without this I get (after disabling Bundlers exception swallowing):

```
/opt/boxen/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/private_gem-1.1.0/lib/private_gem/cli.rb:4:in `<module:PrivateGem>': uninitialized constant PrivateGem::Thor (NameError)
        from /opt/boxen/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/private_gem-1.1.0/lib/private_gem/cli.rb:3:in `<top (required)>'
        from /opt/boxen/rbenv/versions/2.1.4/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/boxen/rbenv/versions/2.1.4/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/boxen/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/private_gem-1.1.0/bin/private_gem:10:in `<top (required)>'
        from /opt/boxen/rbenv/versions/2.1.4/bin/private_gem:23:in `load'
        from /opt/boxen/rbenv/versions/2.1.4/bin/private_gem:23:in `<main>'
```