### PR TITLE
Loosen bundler version dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-before_install: bundle config https://some-fake-gem-server.com 123:456
+before_install:
+  - gem install bundler
+  - bundle config https://some-fake-gem-server.com 123:456
 language: ruby
 rvm:
-  - 2.0
-  - 2.1
+  - 2.5
+  - 2.6

--- a/private_gem.gemspec
+++ b/private_gem.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob('lib/**/*')
   spec.executables   = Dir.glob('bin/**/*').map {|f| File.basename(f)}
 
-  spec.add_dependency 'bundler', '~> 1.7'
+  spec.add_dependency 'bundler', '> 1.7', '< 3.0'
   spec.add_dependency 'thor'
 
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
Bundler 2.0 is out, and Travis is being ornery with bundling any gem using private_gem:

```
Bundler could not find compatible versions for gem "bundler":
  In rails4.2.gemfile:
    private_gem was resolved to 1.1.3, which depends on
      bundler (~> 1.7)
  Current Bundler version:
    bundler (2.0.1)
```

The tests seem green with bundler 2.0, so lets open up the restriction.

cc @staugaard @grosser @craig-day 