### PR TITLE
Upgrade bundled dependencies

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.7', '3.0', '3.1'] # keep in sync with gemspec
+        ruby: ['2.6', '2.7', '3.0', '3.1'] # keep in sync with gemspec
     name: ${{ matrix.ruby }} rake
     steps:
     - uses: zendesk/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,15 +10,14 @@ GEM
   specs:
     bump (0.10.0)
     byebug (11.1.3)
-    maxitest (4.1.0)
-      minitest (>= 5.0.0, < 5.15.0)
-    minitest (5.14.4)
+    maxitest (4.4.1)
+      minitest (>= 5.0.0, < 5.18.0)
+    minitest (5.17.0)
     rake (13.0.6)
     thor (1.2.1)
 
 PLATFORMS
-  x86_64-darwin-20
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   bump
@@ -28,4 +27,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.3.10
+   2.4.9

--- a/private_gem.gemspec
+++ b/private_gem.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'byebug'
 
-  spec.required_ruby_version = '>= 2.4' # keep in sync with .github/workflows/actions.yml
+  spec.required_ruby_version = '>= 2.6' # keep in sync with .github/workflows/actions.yml
 end


### PR DESCRIPTION
Drop support for Ruby 2.4 and 2.5 & upgrade dependencies.